### PR TITLE
Fix import command on Windows and with custom classPrefix

### DIFF
--- a/lib/commands/muenzpraeger/swagger/import.js
+++ b/lib/commands/muenzpraeger/swagger/import.js
@@ -33,7 +33,7 @@ class Import extends command_1.SfdxCommand {
         const overwrite = this.flags.force ? '' : '-s';
         if (javaInstalled && this.flags.apiversion) {
             let pluginDir = __dirname;
-            pluginDir = pluginDir.replace('/lib/commands/muenzpraeger/swagger', '');
+            pluginDir = pluginDir.replace(path_1.join('lib', 'commands', 'muenzpraeger', 'swagger'), '');
             const jarPath = path_1.join(pluginDir, 'resources', 'swagger-codegen-cli.jar');
             let script = `java -jar ${jarPath} generate -i ${this.flags.path} -l apex -o ${this.flags.outputdir} ${overwrite}`;
             if (this.flags.apiVersion) {

--- a/lib/commands/muenzpraeger/swagger/import.js
+++ b/lib/commands/muenzpraeger/swagger/import.js
@@ -44,7 +44,7 @@ class Import extends command_1.SfdxCommand {
                 script = `${script} -DapiVersion=${apiVersion}`;
             }
             if (this.flags.classprefix) {
-                script = `${script} --classPrefix=${this.flags.classprefix}`;
+                script = `${script} -DclassPrefix=${this.flags.classprefix}`;
             }
             const swaggerGen = await runSwaggerJar(script);
             if (swaggerGen) {


### PR DESCRIPTION
Import command builds the correct path to find the swagger-codegen-cli.jar, and allows the setting of a custom classPrefix.